### PR TITLE
Add landscape.yaml validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate-landscape:
+    runs-on: ubuntu-latest
+    name: "Validate landscape.yml file"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cncf/landscape2-validate-action@v2
+        with:
+          target_kind: data
+          target_path: ./landscape.yml


### PR DESCRIPTION
This workflow validates that the `landscape.yml` file is valid on every pull request. It'd be great if you could update the repository's settings so that PRs cannot be merged unless this check passes. This way you'll ensure that the `landscape.yml` stays valid and the landscape build doesn't break.