### PR TITLE
Update landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -67,7 +67,7 @@ landscape:
           name: Centillion
           homepage_url: https://centillion.ai
           logo: centillion.svg
-          crunchbase: https://www.crunchbase.com/organization/centillion
+          crunchbase: https://www.crunchbase.com/organization/centillion-group-inc
         - item:
           name: Charter Communications
           homepage_url: https://spectrum.com
@@ -113,9 +113,9 @@ landscape:
         logo: 5gff.svg
       - item:
         name: A1
-        homepage_url: https://www.a1.mk
+        homepage_url: http://www.a1.net/
         logo: a1.svg
-        crunchbase: https://www.crunchbase.com/organization/a1-cd30
+        crunchbase: https://www.crunchbase.com/organization/a1-telekom-austria-ag
       - item:
         name: ACL Digital
         homepage_url: https://www.acldigital.com/


### PR DESCRIPTION
Changes in A1 and Centillion.ai data:
For A1links were leading to their subsidiary in Northern Macedonia while headquarters are in Austria.
For Centillion the Crunbase link was directing to other company with the same name but offering "Graphic Design, Product Branding" in Croatia.