### PR TITLE
Update second_path for all organizations

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -715,7 +715,7 @@ landscape:
             logo: infobip.svg
             second_path:
               - "Operation / Hyperscalers, CPaaS Providers, Aggregators"
-              - 'Solution Provider / Portal Solution Providers"
+              - "Solution Provider / Portal Solution Providers"
           - item:
             name: InfoLysis
             homepage_url: http://www.infolysis.com/


### PR DESCRIPTION
# Update second_path for all organizations

This PR updates the `second_path` entries for both Members and Participating Organizations.

### Summary of Changes
- Updated 114+ organizations with correct second_path mappings
- Added second_path for previously missing entries
- Standardized category mappings:
  - **Planning**: Associations, Ecosystem Consultants & Training Partners, Research Partners
  - **Integration**: System Integrators
  - **Solution Provider**: ISVs, Portal/API Exposure/Transformation/Network Capability Solution Providers
  - **Operation**: API Customers, Hyperscalers/CPaaS/Aggregators, Operators

### Relation to Existing PRs
This PR supersedes and combines the work from:
- #167 (Update Members)
- #168 (Update Participating Orgs)

Both PRs have become stale due to new additions to the landscape. This PR provides a comprehensive update.

### Review Notes
- Only `second_path` entries are modified
- 3 organizations still lack second_path (see list below) - these need manual review as they're not in the CSV

**Organizations without second_path** (not in CSV data):
- Etisalat
- plusmo
- Telcoflo

@MarkusKuemmerle please review