### PR TITLE
Move Members out of second_path and Ecosystem

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -225,12 +225,72 @@ landscape:
       - subcategory:
         name: Associations
         items:
+          - item:
+            name: OpenID Foundation
+            homepage_url: https://openid.org/
+            logo: openid_foundation.svg
+            description: OpenID Foundation promotes "Open and Safe Identity Layer" in the Cyberspace.
+            crunchbase: https://www.crunchbase.com/organization/openid-foundation
+            twitter: https://twitter.com/openid
+            extra:
+              linkedin_url: https://www.linkedin.com/company/openid-foundation
+          - item:
+            name: Open Mobile Alliance (OMA)
+            homepage_url: https://openmobilealliance.org/
+            logo: open_mobile_alliance_oma.svg
+            description: OMA SpecWorks – a new approach to standards development  Streamlined processes and expertise from across the wireless industry focused on delivering specifications at the services layer that support the billions of new and existing fixed and mobile ter...
+            twitter: https://twitter.com/OMASpecWorks
+            organization:
+              name: Open Mobile Alliance (OMA)
+              linkedin: https://www.linkedin.com/company/open-mobile-alliance
+            extra:
+              linkedin_url: https://www.linkedin.com/company/open-mobile-alliance
       - subcategory:
         name: Ecosystem Consultants & Training Partners
         items:
+          - item:
+            name: Accenture Global Solutions Limited
+            homepage_url: https://accenture.com/
+            logo: accenture_global_solutions_limited.svg
+            description: Founded in 1989 and headquartered in Dublin, Ireland, Accenture is a company that provides services and solutions in strategy, consulting, digital, technology, and operations. The company serves customers in industries including communications, media and technology, financial services, health and public service, as well as products and resources.
+            crunchbase: https://www.crunchbase.com/organization/accenture
+            twitter: https://twitter.com/Accenture
+            extra:
+              linkedin_url: https://www.linkedin.com/company/accenture
       - subcategory:
         name: Research Partners
         items:
+          - item:
+            name: UFRN
+            homepage_url: https://ufrn.br/
+            logo: ufrn.svg
+            second_path: 
+              - Planning / Research Partners
+            description: The Federal University of Rio Grande do Norte (UFRN) is a prestigious public Brazilian university located in Natal, Brazil. Established in 1960, UFRN offers a wide range of undergraduate and graduate programs across 60 departments. Known for its resear...
+            organization:
+              name: UFRN
+          - item:
+            name: University of California, Berkeley
+            homepage_url: https://berkeley.edu/
+            logo: university_of_california_berkeley.svg
+            description: University of California Berkeley is the oldest of the campuses under the University of California umbrella. The university has made its mark as one of the premier research institutions in the country. The student body consists of an estimated 25,000+ undergraduates and 10,000+ graduate students.
+            crunchbase: https://www.crunchbase.com/organization/university-of-california-berkeley
+            twitter: https://twitter.com/UCBerkeley
+            second_path: 
+              - Planning / Research Partners
+            extra:
+              linkedin_url: https://www.linkedin.com/company/uc-berkeley
+          - item:
+            name: University of Colorado Boulder
+            homepage_url: https://colorado.edu/
+            logo: university_of_colorado_boulder.svg
+            description: The University of Colorado at Boulder is a public research university located in Boulder, Colorado. It is the flagship university of the University of Colorado system and was founded five months before Colorado was admitted to the union in 1876. It is comprised of nine colleges and schools.
+            crunchbase: https://www.crunchbase.com/organization/university-of-colorado-boulder
+            twitter: https://twitter.com/CUBoulder
+            second_path: 
+              - Planning / Research Partners
+            extra:
+              linkedin_url: https://www.linkedin.com/company/university-of-colorado
   - category:
     name: Integration
     subcategories:
@@ -243,12 +303,44 @@ landscape:
       - subcategory:
         name: Independent Software Vendors
         items:
+          - item:
+            name: Aleph Zero Foundation
+            homepage_url: https://alephzero.org/
+            logo: aleph_zero_foundation.svg
+            description: Aleph Zero is a non-profit organization dedicated to advancing decentralized technologies. They offer an enterprise-grade public blockchain with private smart contracts powered by AZERO. Their mission is to create a secure blockchain ecosystem and deve...
+            organization:
+              name: Aleph Zero Foundation
+              linkedin: https://www.linkedin.com/company/alephzero
+            extra:
+              linkedin_url: https://www.linkedin.com/company/alephzero
       - subcategory:
         name: Portal Solution Providers
         items:
+          - item:
+            name: Nokia Corporation
+            homepage_url: https://nokia.com/
+            logo: nokia_corporation.svg
+            description: 'Nokia Corporation is a Finland-based company that invests in technologies. The company operates through three business segments: Nokia Networks, HERE and Nokia Technologies. Nokia Networks offers network infrastructure software, hardware, and services. Nokia Networks has two segments: Mobile Broadband and Global Services. HERE offers maps, a location platform, and location experiences across different screens and operating systems. HERE offer maps for around 190 countries, voice guided navigation for 99 countries in around 50 languages and live traffic information for around 44 countries. Nokia Technologies develops and licenses technologies. Nokia Technologies manages an Intellectual Property (IP) portfolio of approximately 10,000 patent families consisted of approximately 30,000 individual patents and patent applications.'
+            crunchbase: https://www.crunchbase.com/organization/nokia
+            twitter: https://twitter.com/nokia
+            second_path:
+              - Solution Provider / API Exposure Platform Solution Providers
+              - Solution Provider / Network Capability Solution Providers
+              - Solution Provider / Transformation Function Solution Providers              
+            extra:
+              linkedin_url: https://www.linkedin.com/company/nokianet
       - subcategory:
         name: API Exposure Platform Solution Providers
         items:
+          - item:
+            name: Ericsson AB
+            homepage_url: https://ericsson.com/en
+            logo: ericsson_ab.svg
+            second_path:              
+              - Solution Provider / Network Capability Solution Providers
+              - Solution Provider / Transformation Function Solution Providers
+            organization:
+              name: Ericsson AB
       - subcategory:
         name: Transformation Function Solution Providers
         items:
@@ -261,12 +353,143 @@ landscape:
       - subcategory:
         name: API Customers
         items:
+          - item:
+            name: IndyKite Inc.
+            homepage_url: https://indykite.com/
+            logo: indykite_inc.svg
+            description: Sky is blue - 4IR is here. Curious to know what will be announced Apr 20, 2020 – subscribe here.
+            twitter: https://twitter.com/indykiteone
+            organization:
+              name: IndyKite Inc.
+              linkedin: https://www.linkedin.com/company/indykite
+            extra:
+              linkedin_url: https://www.linkedin.com/company/indykite
+          - item:
+            name: KYXSTART
+            homepage_url: https://kyxstart.com/
+            logo: kyxstart.svg
+            organization:
+              name: KYXSTART
+          - item:
+            name: Nearby Computing
+            homepage_url: https://nearbycomputing.com/
+            logo: nearby_computing.svg
+            description: 'Nearby Computing: Revolutionizing network management with cutting-edge automation for Telcos & Enterprises.'
+            organization:
+              name: Nearby Computing
       - subcategory:
         name: Hyperscalers, CPaaS Providers, Aggregators
         items:
+          - item:
+            name: Aduna Global LLC
+            homepage_url: https://adunaglobal.com/
+            logo: aduna_global_llc.svg
+          - item:
+            name: Sent, Inc.
+            homepage_url: https://sent.dm/
+            logo: sent_inc.svg
+          - item:
+            name: Shabodi
+            homepage_url: https://shabodi.com/
+            logo: shabodi.svg
+            description: Shabodi is a company that empowers enterprises, system integrators, and telcos to build high-performance enterprise applications on advanced networks.
+            organization:
+              name: Shabodi
+              linkedin: https://www.linkedin.com/company/shabodi
+            extra:
+              linkedin_url: https://www.linkedin.com/company/shabodi
       - subcategory:
         name: Operators
         items:
+          - item:
+            name: Cable Television Laboratories Inc.
+            homepage_url: https://cablelabs.com/
+            logo: cable_television_laboratories_inc.svg
+            description: Founded in 1988, CableLabs is a non-profit research and development consortium that serves to define interoperable solutions among cable operator members and their technology vendors in order to reduce costs, create competition in the supply chain, and drive scale.  CableLabs is dedicated to creating innovative ideas that significantly impact their cable operator members' business. The company is headquartered in Louisville, Colorado.
+            crunchbase: https://www.crunchbase.com/organization/cablelabs
+            twitter: https://twitter.com/CableLabs
+            extra:
+              linkedin_url: https://www.linkedin.com/company/cablelabs
+          - item:
+            name: Charter Communications
+            homepage_url: https://spectrum.com/
+            logo: charter_communications.svg
+            description: Charter Communications, Inc., is an American telecommunications and mass media company that offers its services to consumers and businesses under the branding of Spectrum.
+            crunchbase: https://www.crunchbase.com/organization/time-warner-cable
+            twitter: https://twitter.com/GetSpectrum
+            extra:
+              linkedin_url: https://www.linkedin.com/company/spectrum
+          - item:
+            name: Deutsche Telekom AG
+            homepage_url: https://telekom.com/
+            logo: deutsche_telekom_ag.svg
+            description: Founded in 1995, Deutsche Telekom AG is a Germany-based integrated telecommunications provider, offering its customers around the world a portfolio of services in the areas of telecommunications and information technology.
+            crunchbase: https://www.crunchbase.com/organization/deutsche-telekom
+            twitter: https://twitter.com/deutschetelekom
+            extra:
+              linkedin_url: https://www.linkedin.com/company/telekom
+          - item:
+            name: Orange SA
+            homepage_url: https://orange.com/
+            logo: orange_sa.svg
+            description: |-
+              Orange is one of the world’s leading telecommunications operators with revenues of 39.7 billion euros in 2023 and 128,000 employees worldwide at 30 June 2024, including 72,000 employees in France. The Group has a total customer base of 285 million customers worldwide at 30 June 2024, including 246 million mobile customers and 21 million fixed broadband customers. These figures have been restated to account for the deconsolidation of certain activities in Spain following the creation of MASORANGE. The Group is present in 26 countries (including non-consolidated countries).
+              Orange is also a leading provider of global IT and telecommunication services to multinational companies under the brand Orange Business. In February 2023, the Group presented its strategic plan 'Lead the Future', built on a new business model and guided by responsibility and efficiency. 'Lead the Future' capitalizes on network excellence to reinforce Orange's leadership in service quality.
+              Orange is listed on Euronext Paris (symbol ORA) and on the New York Stock Exchange (symbol ORAN).
+              For more information on the internet and on your mobile: www.orange.com, www.orange-business.com and the Orange News app or to follow us on X: @presseorange.
+
+              Orange and any other Orange product or service names included in this material are trademarks of Orange or Orange Brand Services Limited.
+            crunchbase: https://www.crunchbase.com/organization/orange
+            twitter: https://twitter.com/orange
+            extra:
+              linkedin_url: https://www.linkedin.com/company/orange-services
+          - item:
+            name: Telefonica, S.A.
+            homepage_url: https://telefonica.com/
+            logo: telefonica_s_a.svg
+            description: Telefónica, SA is a Spanish multinational telecommunications company headquartered in Madrid, Spain.
+            crunchbase: https://www.crunchbase.com/organization/telefonica
+            twitter: https://twitter.com/Telefonica
+            extra:
+              linkedin_url: https://www.linkedin.com/company/telefonica-global-solutions
+          - item:
+            name: T-Mobile PCS Holdings LLC
+            homepage_url: https://t-mobile.com/
+            logo: t_mobile_pcs_holdings_llc.svg
+            description: "As America's Un-carrier, T-Mobile US, Inc. (NASDAQ: TMUS) is redefining the way consumers and businesses buy wireless services through leading product and service innovation. The Company's advanced nationwide 4G LTE network delivers outstanding wireless experiences to 67.4 million customers who are unwilling to compromise on quality and value. Based in Bellevue, Washington, T-Mobile US provides services through its subsidiaries and operates its flagship brands, T-Mobile and MetroPCS."
+            crunchbase: https://www.crunchbase.com/organization/t-mobile
+            twitter: https://twitter.com/TMobile
+            extra:
+              linkedin_url: https://www.linkedin.com/company/metropcs
+          - item:
+            name: Verizon Corporate Services
+            homepage_url: https://verizon.com/
+            logo: verizon_corporate_services.svg
+            description: Verizon is a telecommunications company that offers broadband and other wireless and wireline communications services to consumer, business, government, and wholesale customers. Verizon is headquartered in New York City, New York.
+            crunchbase: https://www.crunchbase.com/organization/verizon
+            twitter: https://twitter.com/Verizon
+            extra:
+              linkedin_url: https://www.linkedin.com/company/verizon
+          - item:
+            name: Vodafone Group Plc.
+            homepage_url: https://vodafone.com/
+            logo: vodafone_group_plc.svg
+            description: |-
+              Vodafone is one of the worlds largest telecommunications companies and provides a range of services including voice, messaging, data and fixed communications. Vodafone has mobile operations in 26 countries, partners with mobile networks in 51 more, and fixed broadband operations in 17 markets. As of June 2016, Vodafone had 465 million mobile customers and 13.7 million fixed broadband customers.
+
+              --- Merged Data:
+
+              Idea Cellular Limited was an Indian mobile network operator based at Mumbai, Maharashtra.
+
+              --- Merged Data:
+
+              Vodafone Group plc /ˈvoʊdəfoʊn/ is a British multinational telecommunications company.
+            crunchbase: https://www.crunchbase.com/organization/vodafone
+            twitter: https://twitter.com/VodafoneGroup
+            second_path:
+              - Operation / Operators
+            extra:
+              linkedin_url: https://www.linkedin.com/company/vodafone
   - category:
     name: Participating Organizations
     subcategories:
@@ -286,31 +509,14 @@ landscape:
             logo: a1.svg
             crunchbase: https://www.crunchbase.com/organization/a1-telekom-austria-ag
             second_path:
-              - Operation / Operators
-          - item:
-            name: Accenture Global Solutions Limited
-            homepage_url: https://accenture.com/
-            logo: accenture_global_solutions_limited.svg
-            description: Founded in 1989 and headquartered in Dublin, Ireland, Accenture is a company that provides services and solutions in strategy, consulting, digital, technology, and operations. The company serves customers in industries including communications, media and technology, financial services, health and public service, as well as products and resources.
-            crunchbase: https://www.crunchbase.com/organization/accenture
-            twitter: https://twitter.com/Accenture
-            second_path: 
-              - Planning / Ecosystem Consultants & Training Partners
-            extra:
-              linkedin_url: https://www.linkedin.com/company/accenture
+              - Operation / Operators          
           - item:
             name: ACL Digital
             homepage_url: https://www.acldigital.com/
             logo: acldigital.svg
             crunchbase: https://www.crunchbase.com/organization/alten-calsoft-labs
             second_path:
-              - Integration / System Integrators
-          - item:
-            name: Aduna Global LLC
-            homepage_url: https://adunaglobal.com/
-            logo: aduna_global_llc.svg
-            second_path:
-              - Operation / Hyperscalers, CPaaS Providers, Aggregators
+              - Integration / System Integrators          
           - item:
             name: America Movil
             homepage_url: https://www.americamovil.com/
@@ -329,19 +535,7 @@ landscape:
             logo: akross.svg
             crunchbase: https://www.crunchbase.com/organization/akross
             second_path:
-              - Integration / System Integrators
-          - item:
-            name: Aleph Zero Foundation
-            homepage_url: https://alephzero.org/
-            logo: aleph_zero_foundation.svg
-            second_path:
-              - Solution Provider / Independent Software Vendors
-            description: Aleph Zero is a non-profit organization dedicated to advancing decentralized technologies. They offer an enterprise-grade public blockchain with private smart contracts powered by AZERO. Their mission is to create a secure blockchain ecosystem and deve...
-            organization:
-              name: Aleph Zero Foundation
-              linkedin: https://www.linkedin.com/company/alephzero
-            extra:
-              linkedin_url: https://www.linkedin.com/company/alephzero
+              - Integration / System Integrators          
           - item:
             name: Almuqeet
             homepage_url: https://almuqeet.net/
@@ -447,18 +641,7 @@ landscape:
             logo: broadpeak.svg
             crunchbase: https://www.crunchbase.com/organization/broadpeak
             second_path:
-              - Operation / API Customers
-          - item:
-            name: Cable Television Laboratories Inc.
-            homepage_url: https://cablelabs.com/
-            logo: cable_television_laboratories_inc.svg
-            description: Founded in 1988, CableLabs is a non-profit research and development consortium that serves to define interoperable solutions among cable operator members and their technology vendors in order to reduce costs, create competition in the supply chain, and drive scale.  CableLabs is dedicated to creating innovative ideas that significantly impact their cable operator members' business. The company is headquartered in Louisville, Colorado.
-            crunchbase: https://www.crunchbase.com/organization/cablelabs
-            twitter: https://twitter.com/CableLabs
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/cablelabs
+              - Operation / API Customers          
           - item:
             name: Capgemini
             homepage_url: https://www.capgemini.com/
@@ -472,18 +655,7 @@ landscape:
             logo: centillion.svg
             crunchbase: https://www.crunchbase.com/organization/centillion-group-inc
             second_path:
-              - Operation / API Customers
-          - item:
-            name: Charter Communications
-            homepage_url: https://spectrum.com/
-            logo: charter_communications.svg
-            description: Charter Communications, Inc., is an American telecommunications and mass media company that offers its services to consumers and businesses under the branding of Spectrum.
-            crunchbase: https://www.crunchbase.com/organization/time-warner-cable
-            twitter: https://twitter.com/GetSpectrum
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/spectrum
+              - Operation / API Customers          
           - item:
             name: Chenosis
             homepage_url: https://chenosis.io/
@@ -607,18 +779,7 @@ landscape:
             logo: detecon.svg
             crunchbase: https://www.crunchbase.com/organization/detecon-international-consulting
             second_path: 
-              - Planning / Ecosystem Consultants & Training Partners
-          - item:
-            name: Deutsche Telekom AG
-            homepage_url: https://telekom.com/
-            logo: deutsche_telekom_ag.svg
-            description: Founded in 1995, Deutsche Telekom AG is a Germany-based integrated telecommunications provider, offering its customers around the world a portfolio of services in the areas of telecommunications and information technology.
-            crunchbase: https://www.crunchbase.com/organization/deutsche-telekom
-            twitter: https://twitter.com/deutschetelekom
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/telekom
+              - Planning / Ecosystem Consultants & Training Partners          
           - item:
             name: Domos
             homepage_url: https://www.joindomos.com/
@@ -656,17 +817,7 @@ landscape:
             homepage_url: https://www.edgexr.net
             logo: edgexr.svg
             second_path:
-              - Operation / API Customers
-          - item:
-            name: Ericsson AB
-            homepage_url: https://ericsson.com/en
-            logo: ericsson_ab.svg
-            second_path:
-              - Solution Provider / API Exposure Platform Solution Providers
-              - Solution Provider / Network Capability Solution Providers
-              - Solution Provider / Transformation Function Solution Providers
-            organization:
-              name: Ericsson AB
+              - Operation / API Customers          
           - item:
             name: Etisalat
             homepage_url: https://www.etisalat.com/
@@ -785,20 +936,7 @@ landscape:
             homepage_url: https://testbed.ieee.org/
             logo: IEEE5G6GTestbed.svg.svg
             second_path: 
-              - Planning / Research Partners
-          - item:
-            name: IndyKite Inc.
-            homepage_url: https://indykite.com/
-            logo: indykite_inc.svg
-            description: Sky is blue - 4IR is here. Curious to know what will be announced Apr 20, 2020 – subscribe here.
-            twitter: https://twitter.com/indykiteone
-            second_path:
-              - Operation / API Customers
-            organization:
-              name: IndyKite Inc.
-              linkedin: https://www.linkedin.com/company/indykite
-            extra:
-              linkedin_url: https://www.linkedin.com/company/indykite
+              - Planning / Research Partners          
           - item:
             name: Infobip
             homepage_url: https://www.infobip.com/
@@ -894,14 +1032,6 @@ landscape:
             logo: kubermatic.svg
             second_path:
               - Solution Provider / Network Capability Solution Providers
-          - item:
-            name: KYXSTART
-            homepage_url: https://kyxstart.com/
-            logo: kyxstart.svg
-            second_path:
-              - Operation / API Customers
-            organization:
-              name: KYXSTART
           - item:
             name: LatenceTech
             homepage_url: https://www.latencetech.com/
@@ -1049,16 +1179,7 @@ landscape:
             homepage_url: https://www.demokritos.gr/
             logo: demokritos.svg
             second_path: 
-              - Planning / Research Partners
-          - item:
-            name: Nearby Computing
-            homepage_url: https://nearbycomputing.com/
-            logo: nearby_computing.svg
-            second_path:
-              - Operation / API Customers
-            description: 'Nearby Computing: Revolutionizing network management with cutting-edge automation for Telcos & Enterprises.'
-            organization:
-              name: Nearby Computing
+              - Planning / Research Partners          
           - item:
             name: Netcracker
             homepage_url: https://www.netcracker.com/
@@ -1076,21 +1197,7 @@ landscape:
             homepage_url: https://www.ngmn.org/
             logo: ngmn.svg
             second_path:
-              - Planning / Associations
-          - item:
-            name: Nokia Corporation
-            homepage_url: https://nokia.com/
-            logo: nokia_corporation.svg
-            description: 'Nokia Corporation is a Finland-based company that invests in technologies. The company operates through three business segments: Nokia Networks, HERE and Nokia Technologies. Nokia Networks offers network infrastructure software, hardware, and services. Nokia Networks has two segments: Mobile Broadband and Global Services. HERE offers maps, a location platform, and location experiences across different screens and operating systems. HERE offer maps for around 190 countries, voice guided navigation for 99 countries in around 50 languages and live traffic information for around 44 countries. Nokia Technologies develops and licenses technologies. Nokia Technologies manages an Intellectual Property (IP) portfolio of approximately 10,000 patent families consisted of approximately 30,000 individual patents and patent applications.'
-            crunchbase: https://www.crunchbase.com/organization/nokia
-            twitter: https://twitter.com/nokia
-            second_path:
-              - Solution Provider / API Exposure Platform Solution Providers
-              - Solution Provider / Network Capability Solution Providers
-              - Solution Provider / Transformation Function Solution Providers
-              - Solution Provider / Portal Solution Providers
-            extra:
-              linkedin_url: https://www.linkedin.com/company/nokianet
+              - Planning / Associations          
           - item:
             name: NOS
             homepage_url: https://www.nos.pt/
@@ -1108,20 +1215,7 @@ landscape:
             homepage_url: https://www.nttdata.com/
             logo: nttdata.svg
             second_path:
-              - Solution Provider / Network Capability Solution Providers
-          - item:
-            name: Open Mobile Alliance (OMA)
-            homepage_url: https://openmobilealliance.org/
-            logo: open_mobile_alliance_oma.svg
-            second_path:
-              - Planning / Associations
-            description: OMA SpecWorks – a new approach to standards development  Streamlined processes and expertise from across the wireless industry focused on delivering specifications at the services layer that support the billions of new and existing fixed and mobile ter...
-            twitter: https://twitter.com/OMASpecWorks
-            organization:
-              name: Open Mobile Alliance (OMA)
-              linkedin: https://www.linkedin.com/company/open-mobile-alliance
-            extra:
-              linkedin_url: https://www.linkedin.com/company/open-mobile-alliance
+              - Solution Provider / Network Capability Solution Providers          
           - item:
             name: Openexpand
             homepage_url: https://openxpand.com/
@@ -1136,17 +1230,6 @@ landscape:
             logo: opensesame.svg
             second_path:
               - Operation / API Customers
-          - item:
-            name: OpenID Foundation
-            homepage_url: https://openid.org/
-            logo: openid_foundation.svg
-            description: OpenID Foundation promotes "Open and Safe Identity Layer" in the Cyberspace.
-            crunchbase: https://www.crunchbase.com/organization/openid-foundation
-            twitter: https://twitter.com/openid
-            second_path:
-              - Planning / Associations
-            extra:
-              linkedin_url: https://www.linkedin.com/company/openid-foundation
           - item:
             name: Optare Solutions
             homepage_url: https://optaresolutions.com/
@@ -1165,24 +1248,7 @@ landscape:
             homepage_url: https://www.oracle.com/
             logo: oracle.svg
             second_path:
-              - Solution Provider / Network Capability Solution Providers
-          - item:
-            name: Orange SA
-            homepage_url: https://orange.com/
-            logo: orange_sa.svg
-            description: |-
-              Orange is one of the world’s leading telecommunications operators with revenues of 39.7 billion euros in 2023 and 128,000 employees worldwide at 30 June 2024, including 72,000 employees in France. The Group has a total customer base of 285 million customers worldwide at 30 June 2024, including 246 million mobile customers and 21 million fixed broadband customers. These figures have been restated to account for the deconsolidation of certain activities in Spain following the creation of MASORANGE. The Group is present in 26 countries (including non-consolidated countries).
-              Orange is also a leading provider of global IT and telecommunication services to multinational companies under the brand Orange Business. In February 2023, the Group presented its strategic plan 'Lead the Future', built on a new business model and guided by responsibility and efficiency. 'Lead the Future' capitalizes on network excellence to reinforce Orange's leadership in service quality.
-              Orange is listed on Euronext Paris (symbol ORA) and on the New York Stock Exchange (symbol ORAN).
-              For more information on the internet and on your mobile: www.orange.com, www.orange-business.com and the Orange News app or to follow us on X: @presseorange.
-
-              Orange and any other Orange product or service names included in this material are trademarks of Orange or Orange Brand Services Limited.
-            crunchbase: https://www.crunchbase.com/organization/orange
-            twitter: https://twitter.com/orange
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/orange-services
+              - Solution Provider / Network Capability Solution Providers          
           - item:
             name: phine.tech GmbH
             homepage_url: https://phine.tech/
@@ -1269,25 +1335,7 @@ landscape:
             homepage_url: https://www.sekura.com/
             logo: sekura.svg
             second_path:
-              - Operation / API Customers
-          - item:
-            name: Sent, Inc.
-            homepage_url: https://sent.dm/
-            logo: sent_inc.svg
-            second_path:
-              - Operation / Hyperscalers, CPaaS Providers, Aggregators
-          - item:
-            name: Shabodi
-            homepage_url: https://shabodi.com/
-            logo: shabodi.svg
-            second_path:
-              - Solution Provider / API Exposure Platform Solution Providers
-            description: Shabodi is a company that empowers enterprises, system integrators, and telcos to build high-performance enterprise applications on advanced networks.
-            organization:
-              name: Shabodi
-              linkedin: https://www.linkedin.com/company/shabodi
-            extra:
-              linkedin_url: https://www.linkedin.com/company/shabodi
+              - Operation / API Customers          
           - item:
             name: Simptel
             homepage_url: https://www.siptel.com.sg/
@@ -1364,18 +1412,7 @@ landscape:
             homepage_url: https://www.syniverse.com/
             logo: syniverse.svg
             second_path:
-              - Operation / Hyperscalers, CPaaS Providers, Aggregators
-          - item:
-            name: T-Mobile PCS Holdings LLC
-            homepage_url: https://t-mobile.com/
-            logo: t_mobile_pcs_holdings_llc.svg
-            description: "As America's Un-carrier, T-Mobile US, Inc. (NASDAQ: TMUS) is redefining the way consumers and businesses buy wireless services through leading product and service innovation. The Company's advanced nationwide 4G LTE network delivers outstanding wireless experiences to 67.4 million customers who are unwilling to compromise on quality and value. Based in Bellevue, Washington, T-Mobile US provides services through its subsidiaries and operates its flagship brands, T-Mobile and MetroPCS."
-            crunchbase: https://www.crunchbase.com/organization/t-mobile
-            twitter: https://twitter.com/TMobile
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/metropcs
+              - Operation / Hyperscalers, CPaaS Providers, Aggregators          
           - item:
             name: Tata Consultancy Services (TCS)
             homepage_url: https://www.tcs.com/
@@ -1393,18 +1430,7 @@ landscape:
             homepage_url: https://telcoflo.dev/
             logo: telcoflo.svg
             second_path:
-              - Operation / Hyperscalers, CPaaS Providers, Aggregators
-          - item:
-            name: Telefonica, S.A.
-            homepage_url: https://telefonica.com/
-            logo: telefonica_s_a.svg
-            description: Telefónica, SA is a Spanish multinational telecommunications company headquartered in Madrid, Spain.
-            crunchbase: https://www.crunchbase.com/organization/telefonica
-            twitter: https://twitter.com/Telefonica
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/telefonica-global-solutions
+              - Operation / Hyperscalers, CPaaS Providers, Aggregators          
           - item:
             name: Telenor
             homepage_url: https://www.telenor.com/
@@ -1453,38 +1479,7 @@ landscape:
             logo: trusense.svg            
             second_path:
               - Operation / API Customers
-              - Solution Provider / Network Capability Solution Providers
-          - item:
-            name: UFRN
-            homepage_url: https://ufrn.br/
-            logo: ufrn.svg
-            second_path: 
-              - Planning / Research Partners
-            description: The Federal University of Rio Grande do Norte (UFRN) is a prestigious public Brazilian university located in Natal, Brazil. Established in 1960, UFRN offers a wide range of undergraduate and graduate programs across 60 departments. Known for its resear...
-            organization:
-              name: UFRN
-          - item:
-            name: University of California, Berkeley
-            homepage_url: https://berkeley.edu/
-            logo: university_of_california_berkeley.svg
-            description: University of California Berkeley is the oldest of the campuses under the University of California umbrella. The university has made its mark as one of the premier research institutions in the country. The student body consists of an estimated 25,000+ undergraduates and 10,000+ graduate students.
-            crunchbase: https://www.crunchbase.com/organization/university-of-california-berkeley
-            twitter: https://twitter.com/UCBerkeley
-            second_path: 
-              - Planning / Research Partners
-            extra:
-              linkedin_url: https://www.linkedin.com/company/uc-berkeley
-          - item:
-            name: University of Colorado Boulder
-            homepage_url: https://colorado.edu/
-            logo: university_of_colorado_boulder.svg
-            description: The University of Colorado at Boulder is a public research university located in Boulder, Colorado. It is the flagship university of the University of Colorado system and was founded five months before Colorado was admitted to the union in 1876. It is comprised of nine colleges and schools.
-            crunchbase: https://www.crunchbase.com/organization/university-of-colorado-boulder
-            twitter: https://twitter.com/CUBoulder
-            second_path: 
-              - Planning / Research Partners
-            extra:
-              linkedin_url: https://www.linkedin.com/company/university-of-colorado
+              - Solution Provider / Network Capability Solution Providers          
           - item:
             name: Unryo Inc
             homepage_url: https://unryo.com/
@@ -1500,18 +1495,7 @@ landscape:
             homepage_url: https://www.uth-uk.com/
             logo: uth.svg
             second_path:
-              - Solution Provider / Network Capability Solution Providers
-          - item:
-            name: Verizon Corporate Services
-            homepage_url: https://verizon.com/
-            logo: verizon_corporate_services.svg
-            description: Verizon is a telecommunications company that offers broadband and other wireless and wireline communications services to consumer, business, government, and wholesale customers. Verizon is headquartered in New York City, New York.
-            crunchbase: https://www.crunchbase.com/organization/verizon
-            twitter: https://twitter.com/Verizon
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/verizon
+              - Solution Provider / Network Capability Solution Providers          
           - item:
             name: VIAVI Solutions
             homepage_url: https://www.viavisolutions.com/
@@ -1524,27 +1508,7 @@ landscape:
             homepage_url: https://www.virtus.ufcg.edu.br
             logo: virtus.svg
             second_path: 
-              - Planning / Research Partners
-          - item:
-            name: Vodafone Group Plc.
-            homepage_url: https://vodafone.com/
-            logo: vodafone_group_plc.svg
-            description: |-
-              Vodafone is one of the worlds largest telecommunications companies and provides a range of services including voice, messaging, data and fixed communications. Vodafone has mobile operations in 26 countries, partners with mobile networks in 51 more, and fixed broadband operations in 17 markets. As of June 2016, Vodafone had 465 million mobile customers and 13.7 million fixed broadband customers.
-
-              --- Merged Data:
-
-              Idea Cellular Limited was an Indian mobile network operator based at Mumbai, Maharashtra.
-
-              --- Merged Data:
-
-              Vodafone Group plc /ˈvoʊdəfoʊn/ is a British multinational telecommunications company.
-            crunchbase: https://www.crunchbase.com/organization/vodafone
-            twitter: https://twitter.com/VodafoneGroup
-            second_path:
-              - Operation / Operators
-            extra:
-              linkedin_url: https://www.linkedin.com/company/vodafone
+              - Planning / Research Partners          
           - item:
             name: VROMBR
             homepage_url: https://vrombr.games


### PR DESCRIPTION
Moved all members out of ecosystem participants and manually copied them to the second_path categories. Removed second_path from their information as they are manually in the categories.