### PR TITLE
Fix null item in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -290,7 +290,7 @@ landscape:
     subcategories:
       - subcategory:
         name: System Integrators
-        items:
+        items: []
   - category:
     name: Solution Provider
     subcategories:


### PR DESCRIPTION
landscape2-validate-action reads landscape.yml and fails on the items: null