### PR TITLE
Fix remaining null items entries in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -337,10 +337,10 @@ landscape:
               name: Ericsson AB
       - subcategory:
         name: Transformation Function Solution Providers
-        items:
+        items: []
       - subcategory:
         name: Network Capability Solution Providers
-        items:
+        items: []
   - category:
     name: Operation
     subcategories:


### PR DESCRIPTION
## Summary

- Fix two subcategories with null `items:` that cause the landscape2 validator to fail
- "Transformation Function Solution Providers" and "Network Capability Solution Providers" now use `items: []` instead of bare `items:`, matching the fix already applied to "System Integrators" in PR #214

Fixes #215

## Details

The "Build Landscape from LFX" workflow [run 23605828893](https://github.com/camaraproject/camara-landscape/actions/runs/23605828893) fails at validation with:

```
landscape[3].subcategories[3].items: invalid type: unit value, expected a sequence at line 330 column 16
```

PR #214 fixed one instance (System Integrators) but missed these two. The subcategories have no direct items (populated via `second_path` references) but the validator still requires an explicit empty array.