### PR TITLE
Add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Landscape from LFX](https://github.com/camaraproject/camara-landscape/actions/workflows/build.yml/badge.svg)](https://github.com/camaraproject/camara-landscape/actions/workflows/build.yml)
+
 ## Quick Info:
 
 + Landscape is used to maintain Member and project information on our [website](https://camaraproject.org)


### PR DESCRIPTION
Adds a workflow status badge for the "Build Landscape from LFX" workflow to the top of README.md.

The daily build has been failing unnoticed since November 2025 (fixed now via #214 and #216). A visible badge makes build status immediately apparent to anyone visiting the repository.