### PR TITLE
Update Xacria

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1526,8 +1526,12 @@ landscape:
             name: Xacria
             homepage_url: https://www.xacria.com/
             logo: xacria.svg
+            description: Xacria is a technology company focused on transforming the OSS landscape through next-generation automation, orchestration, and closed-loop remediation. Its solutions are designed in alignment with the principles of TM Forum Open Digital Architecture (ODA), supporting North-South intent requests and Mplify-aligned API models for East-West interactions across platforms. As a TM Forum ODA, Component and API Certified member, Xacria develops modular, cloud-native OSS software built on a streaming-based architecture to maximize agility, interoperability, and operational performance.
             second_path:
               - Solution Provider / Network Capability Solution Providers
+            extra:
+              contact: info@xacria.com
+              demo_url: https://www.tmforum.org/catalysts/projects/M25.0.795/Monetizing-federated-connectivity-for-automotive-OEMs
           - item:
             name: Xecurity Pulse
             homepage_url: https://www.xecuritypulse.com/


### PR DESCRIPTION
Update Xacria listing per organization-confirmed response (landscape verification outreach, March 2026). Changes:

Add organization description (trimmed from four paragraphs to the requested 2-3 sentences; full product detail provided by Jose Macaluso is on file). Add contact field (info@xacria.com).
Add demo_url linking to the TM Forum Moonshot Catalyst project page for "Monetizing federated connectivity for automotive OEMs" (DTW Copenhagen, June 2025, first-place Telco Monetization Award).

Category placement confirmed accurate, no changes needed. Confirmed by: Jose Macaluso, Xacria