### PR TITLE
docs: Update README optional fields to use documented data.yml schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 ## Quick Info
 
-- To view the Landscape, go to https://camara.landscape2.io
-- The Landscape is used to maintain Member and Participating Organization information on the [CAMARA website](https://camaraproject.org)
-- CAMARA Landscape Settings: https://github.com/cncf/landscape2-sites/blob/main/camara/settings.yml
+* To view the Landscape, go to <https://camara.landscape2.io>
+* The Landscape is used to maintain Member and Participating Organization information on the [CAMARA website](https://camaraproject.org)
+* CAMARA Landscape Settings: <https://github.com/cncf/landscape2-sites/blob/main/camara/settings.yml>
 
 ## How It Works
 
-The Landscape is generated nightly from the data in this repository using the [Landscape2](https://github.com/cncf/landscape2) tool. Member data is pulled automatically from LFX each night. LFX-managed fields (name, logo, description, homepage) will be overwritten; project-specific fields (second_path, extra) are preserved.
+The Landscape is generated nightly from the data in this repository using the [Landscape2](https://github.com/cncf/landscape2) tool. Member data is pulled automatically from LFX each night. LFX-managed fields (name, logo, description, homepage) will be overwritten; project-specific fields (second\_path, extra) are preserved.
 
 **Members:** To update your organization's name, logo, or description, please do so through your organization's LFX dashboard at `https://myorg.lfx.dev`. Changes will be reflected in the Landscape automatically on the next automatic build.
 
-**Participating Organizations:** To add or update your entry, please open a pull request as described below, or send a request to adm@lists.camaraproject.org.
+**Participating Organizations:** To add or update your entry, please open a pull request as described below, or send a request to [adm@lists.camaraproject.org](mailto:adm@lists.camaraproject.org).
 
 ## Adding or Updating a Participating Organization Entry
 
 Open a pull request adding or updating your entry in alphabetical order in the appropriate section of `landscape.yml`. Logos must be added to the `hosted_logos` folder in `.svg` format.
 
 ### Required Fields
+
 ```yaml
 - item:
   name: <organization name>
@@ -28,18 +29,43 @@ Open a pull request adding or updating your entry in alphabetical order in the a
 ```
 
 If your organization does not have a Crunchbase entry, you may use the following instead of the `crunchbase` field:
+
 ```yaml
   organization:
     name: <organization name>
 ```
 
 ### Optional Fields
-```yaml
-  # Short description of the organization (2-3 sentences)
-  description:
 
+The following fields are supported under the `extra` key and will be rendered in the item detail view on the Landscape. All fields are optional.
+
+```yaml
+  extra:
+    # LinkedIn profile URL for your organization
+    linkedin_url: <url>
+
+    # Primary documentation URL for your organization or product
+    documentation_url: <url>
+
+    # A public-facing contact email address for your organization
+    # (e.g. a team or program inbox, not a personal address)
+    annotations:
+      contact: <email address>
+
+    # One or more links to demos, case studies, developer portals,
+    # or other resources related to CAMARA APIs or network APIs.
+    # Each entry requires both a name and a url.
+    other_links:
+      - name: <descriptive label, e.g. "Developer Portal" or "Live Demo">
+        url: <url>
+      - name: <descriptive label>
+        url: <url>
+```
+
+For entries that should appear in multiple Landscape categories simultaneously, use the `second_path` field:
+
+```yaml
   # One or more landscape categories that reflect your organization's role.
-  # An entry can appear in multiple categories simultaneously.
   # Valid values are:
   #   Planning / Associations
   #   Planning / Ecosystem Consultants & Training Partners
@@ -55,16 +81,9 @@ If your organization does not have a Crunchbase entry, you may use the following
   #   Operation / Operators
   second_path:
     - <Category / Subcategory>
-
-  extra:
-    # A public-facing contact email for your organization
-    # (e.g. a team or program inbox, not a personal address)
-    contact: <email address>
-
-    # Link to a publicly available demo, case study, or use case
-    # related to CAMARA APIs or network APIs
-    demo_url: <url>
 ```
+
+> **Note:** Fields not listed here (such as `extra.contact`, `extra.demo_url`, `annotations.demo_url`, `linkedin`, or `organization.linkedin`) are not part of the documented [Landscape2 data schema](https://github.com/cncf/landscape2/blob/main/docs/config/data.yml) and will be silently ignored by the build tool. Please use only the fields documented above.
 
 ### Logo Requirements
 
@@ -72,6 +91,6 @@ Logos must be in **SVG format** (PNG and JPG are not accepted) and placed in the
 
 SVG files must not contain embedded text elements -- this means any text in your logo (such as your company name or tagline) must be converted to paths/outlines before saving, rather than remaining as editable text. If this step is skipped, the build will fail. Most vector graphics tools handle this automatically or with a simple menu option:
 
-- **Inkscape:** Path > Object to Path
-- **Adobe Illustrator:** Type > Create Outlines
-- **Sketch/Figma:** Use "Outline Stroke" or export as "Flatten" SVG
+* **Inkscape:** Path > Object to Path
+* **Adobe Illustrator:** Type > Create Outlines
+* **Sketch/Figma:** Use "Outline Stroke" or export as "Flatten" SVG

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## How It Works
 
-The Landscape is generated nightly from the data in this repository using the [Landscape2](https://github.com/cncf/landscape2) tool. Member data is pulled automatically from LFX each night. LFX-managed fields (name, logo, description, homepage) will be overwritten; project-specific fields (second\_path, extra) are preserved.
+The Landscape is generated nightly from the data in this repository using the [Landscape2](https://github.com/cncf/landscape2) tool. Member data is pulled automatically from LFX each night. LFX-managed fields (name, logo, description, homepage) will be overwritten; project-specific fields (second_path, extra) are preserved.
 
 **Members:** To update your organization's name, logo, or description, please do so through your organization's LFX dashboard at `https://myorg.lfx.dev`. Changes will be reflected in the Landscape automatically on the next automatic build.
 


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

The README's Optional Fields section documented `extra.contact` and `extra.demo_url`, neither of which is part of the documented [Landscape2 data schema](https://github.com/cncf/landscape2/blob/main/docs/config/data.yml). Both fields are silently ignored by the build tool. This is the same class of issue corrected for landscape.yml entries in #287.

This PR updates the README to document only valid schema fields:

* **`extra.contact`** — replaced with `extra.annotations.contact` (correct nesting per schema)
* **`extra.demo_url`** — replaced with `extra.other_links` (supports multiple named links)
* Added **`extra.linkedin_url`** and **`extra.documentation_url`** as documented optional fields
* Moved `second_path` out of the `extra` block into its own subsection for clarity
* Added a Note callout explicitly listing previously-misused field names to prevent recurrence

#### Which issue(s) this PR fixes:

Related to #287

#### Special notes for reviewers:

No functional changes to landscape.yml or the build process — documentation only. The goal is to ensure contributors submitting new Participating Organization entries use fields that will actually render in the Landscape, rather than fields that are silently dropped.

#### Changelog input

release-note
Updated README to document correct Landscape2 schema fields for optional entry data (annotations.contact, other_links, linkedin_url, documentation_url) and added a note warning against previously-misused field names.