### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+      third-party-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"


### PR DESCRIPTION
#### What type of PR is this?
- chore / enhancement

#### What this PR does / why we need it

Enables Dependabot for the `github-actions` ecosystem so updates to `jmertic/lfx-landscape-tools` and the other pinned actions arrive as regular PRs for review.

The configuration mirrors what is already in use in `project-administration` and `camaraproject.github.io`:
- weekly schedule, Monday
- commit prefix `chore(deps)`
- labels `dependencies` and `github-actions`
- grouped updates: first-party `actions/*` vs. third-party (so `lfx-landscape-tools` bumps arrive in their own group PR, separate from routine `actions/checkout`-style bumps)

#### Supersedes #292

This PR is proposed as a replacement for #292 in response to reviewer feedback that merging Dependabot PRs unattended is not desired at this stage. Changes relative to #292:

1. No auto-merge workflow. A breaking change in `jmertic/lfx-landscape-tools` would otherwise silently break the nightly `build.yml`; PRs should be reviewed before merge.
2. Removed the `groups.all.dependency-type: "production"` block. `dependency-type` is a package-manager concept (npm/pip/etc.) and is not applied to the `github-actions` ecosystem; the block was a no-op.
3. Added `commit-message.prefix`, `labels`, and `open-pull-requests-limit` to match the CAMARA-org convention.